### PR TITLE
K#3290 d:s:c is executed only if db does not exist yet

### DIFF
--- a/install-lib/database-functions.sh
+++ b/install-lib/database-functions.sh
@@ -36,12 +36,6 @@ function create_database_in_container() {
             echo "Error: Database creation failed"
         fi
     fi
-    bin/console doctrine:schema:create
-    if [ $? -eq 0 ]; then
-        echo "Success! Database schema created."
-    else
-        echo "Error: Database schema created failed."
-    fi
 
     _stop_database_container mariadb php
 }


### PR DESCRIPTION
doctrine:schema:create apparaissait deux fois dans le code : 
- une fois dans une boucle qui conditionnait son exécution au fait que la bade de données n'existait pas préalablement
- une fois après la boucle, donc la commande s’exécutait à chaque ./install (peu importe de la base de donnée existe ou non).

J'ai enlevé le code qui s’exécutait à chaque ./install.